### PR TITLE
Upgrade deps to work with Purescript 0.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,14 +12,14 @@
     "url": "git://github.com/justinwoo/purescript-ohyes.git"
   },
   "dependencies": {
-    "purescript-prelude": "^4.1.0",
-    "purescript-console": "^4.1.0",
-    "purescript-typelevel-prelude": "^3.0.0",
-    "purescript-record": "^1.0.0",
-    "purescript-generics-rep": "^6.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-nullable": "^4.0.0",
-    "purescript-variant": "^5.0.0",
+    "purescript-prelude": "^4.1.1",
+    "purescript-console": "^4.2.0",
+    "purescript-typelevel-prelude": "^5.0.0",
+    "purescript-record": "^2.0.1",
+    "purescript-generics-rep": "^6.1.1",
+    "purescript-lists": "^5.4.1",
+    "purescript-nullable": "^4.1.1",
+    "purescript-variant": "^6.0.1",
     "purescript-foreign": "^5.0.0",
     "purescript-has-js-rep": "^0.1.0"
   },
@@ -27,6 +27,6 @@
     "purescript-psci-support": "^4.0.0",
     "purescript-prettier": "^0.2.0",
     "purescript-node-fs-aff": "^6.0.0",
-    "purescript-spec": "^3.0.0"
+    "purescript-spec": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Justin Woo, Csongor Kiss, Rightfold, Joe Kachmar, Josh Burgess, Phil Freeman",
   "license": "MIT",
   "devDependencies": {
-    "prettier": "^1.14.2",
+    "prettier": "^1.18.2",
     "typescript": "^3.0.1"
   }
 }

--- a/src/OhYes.purs
+++ b/src/OhYes.purs
@@ -11,7 +11,7 @@ import HasJSRep (class HasJSRep, class MembersHaveJSRep)
 import Prim.RowList as RL
 import Type.Prelude (class IsSymbol, SProxy(..), reflectSymbol)
 import Type.Proxy (Proxy(..))
-import Type.Row (RLProxy(..), kind RowList)
+import Type.Data.RowList (RLProxy(..))
 
 toTS :: forall a. HasTSRep a => a -> a
 toTS = identity
@@ -86,7 +86,7 @@ instance recordHasTSRep ::
       rlp = RLProxy :: RLProxy rl
       fields = intercalate "," $ toTSRepFields rlp
 
-class HasTSRepFields (rl :: RowList) where
+class HasTSRepFields (rl :: RL.RowList) where
   toTSRepFields :: RLProxy rl -> List String
 
 instance consHasTSRepFields ::
@@ -121,7 +121,7 @@ instance fakeSumRecordHasTSRep ::
       rlp = RLProxy :: RLProxy rl
       members = toFakeSumRecordMembers rlp
 
-class FakeSumRecordMembers (rl :: RowList) where
+class FakeSumRecordMembers (rl :: RL.RowList) where
   toFakeSumRecordMembers :: RLProxy rl -> List String
 
 instance consFakeSumRecordMembers ::


### PR DESCRIPTION
Took a stab at making this work with the new `purescript-typelevel-prelude`, because a project of mine ran into conflicts on that one. I ended up just upgrading everything, so let me know if you'd like to have some of the noise reverted.

`yarn test` finishes successfully.